### PR TITLE
Extract common interface

### DIFF
--- a/src/Authenticate.php
+++ b/src/Authenticate.php
@@ -7,7 +7,7 @@ use Islandis\Exception\AuthenticateError;
 class Authenticate
 {
 	public function __construct(
-		private readonly Verifier $verifier,
+		private readonly VerifierInterface $verifier,
 	) {}
 
 	/**

--- a/src/Authenticate.php
+++ b/src/Authenticate.php
@@ -19,4 +19,9 @@ class Authenticate
 
 		return User::fromVerifier($this->verifier);
 	}
+
+	public function getAuthId(): ?string
+	{
+		return $this->verifier->getAttribute('AuthID');
+	}
 }

--- a/src/User.php
+++ b/src/User.php
@@ -4,7 +4,7 @@ namespace Islandis;
 
 class User
 {
-	public static function fromVerifier(Verifier $verifier): self
+	public static function fromVerifier(VerifierInterface $verifier): self
 	{
 		return new self(
 			(string)$verifier->getAttribute('Name'),

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -17,9 +17,9 @@ use RobRichards\XMLSecLibs\XMLSecEnc;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
-final class Verifier
+final class Verifier implements VerifierInterface
 {
-	const INTERMEDIATE_COMMON_NAME = 'Fullgilt audkenni';
+	private const INTERMEDIATE_COMMON_NAME = 'Fullgilt audkenni';
 
 	private ?DOMDocument $xml;
 	private string $myCertPem;

--- a/src/VerifierInterface.php
+++ b/src/VerifierInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Islandis;
+
+interface VerifierInterface
+{
+	public function verify(string $token): bool;
+
+	public function getAttribute(string $needle): ?string;
+}


### PR DESCRIPTION
Extract a `VerifierInterface` to make testing easier.

Also add `getAuthId` to `Authenticate` to make it easier to always get a common id for logging