### PR TITLE
Include user agent information in ValidationFailure exception

### DIFF
--- a/src/Exception/ValidationFailure.php
+++ b/src/Exception/ValidationFailure.php
@@ -9,7 +9,7 @@ final class ValidationFailure extends \DomainException implements AuthenticateEr
 		return new self('Reference Validation Failed', 1, $e);
 	}
 
-	public static function userAgent(?string $userAgent, string $expected): self
+	public static function userAgent(string $userAgent, ?string $expected): self
 	{
 		return new self(sprintf('User-agent does not match "%s" got "%s"', $expected, $userAgent));
 	}

--- a/src/Exception/ValidationFailure.php
+++ b/src/Exception/ValidationFailure.php
@@ -9,9 +9,9 @@ final class ValidationFailure extends \DomainException implements AuthenticateEr
 		return new self('Reference Validation Failed', 1, $e);
 	}
 
-	public static function userAgent(): self
+	public static function userAgent(string $userAgent, string $expected): self
 	{
-		return new self('User-agent does not match');
+		return new self(sprintf('User-agent does not match "%s" got "%s"', $expected, $userAgent));
 	}
 
 	public static function ip(): self

--- a/src/Exception/ValidationFailure.php
+++ b/src/Exception/ValidationFailure.php
@@ -9,7 +9,7 @@ final class ValidationFailure extends \DomainException implements AuthenticateEr
 		return new self('Reference Validation Failed', 1, $e);
 	}
 
-	public static function userAgent(string $userAgent, string $expected): self
+	public static function userAgent(?string $userAgent, string $expected): self
 	{
 		return new self(sprintf('User-agent does not match "%s" got "%s"', $expected, $userAgent));
 	}

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -115,9 +115,11 @@ final class Verifier implements VerifierInterface
 
 	private function verifyUserAgent(): void
 	{
-		// todo throw on missing useragent
-		if ($this->getAttribute('UserAgent') !== $this->getUserAgent()) {
-			throw ValidationFailure::userAgent();
+		$userAgent = $this->getUserAgent();
+		$expected = $this->getAttribute('UserAgent');
+
+		if ($expected !== $userAgent) {
+			throw ValidationFailure::userAgent($userAgent, $expected);
 		}
 	}
 


### PR DESCRIPTION
I have a user who is somehow failing the User-agent check. I want to know what values are being compared.